### PR TITLE
Add Feature: 定制列增加配置界面，支持根据分割字段前缀并快速生成不含前缀的PropertyName

### DIFF
--- a/src/main/java/com/zzg/mybatis/generator/controller/BaseFXController.java
+++ b/src/main/java/com/zzg/mybatis/generator/controller/BaseFXController.java
@@ -34,16 +34,17 @@ public abstract class BaseFXController implements Initializable {
         Parent loginNode;
         try {
             loginNode = loader.load();
-            BaseFXController controller = loader.getController();
-            dialogStage = new Stage();
-            dialogStage.setTitle(title);
-            dialogStage.initModality(Modality.APPLICATION_MODAL);
-            dialogStage.initOwner(getPrimaryStage());
-            dialogStage.setScene(new Scene(loginNode));
-            dialogStage.setMaximized(false);
-            dialogStage.setResizable(false);
-            dialogStage.show();
-            controller.setDialogStage(dialogStage);
+            BaseFXController controller     = loader.getController();
+            // fix bug: 嵌套弹出时会发生dialogStage被覆盖的情况
+            Stage            tmpDialogStage = new Stage();
+            tmpDialogStage.setTitle(title);
+            tmpDialogStage.initModality(Modality.APPLICATION_MODAL);
+            tmpDialogStage.initOwner(getPrimaryStage());
+            tmpDialogStage.setScene(new Scene(loginNode));
+            tmpDialogStage.setMaximized(false);
+            tmpDialogStage.setResizable(false);
+            tmpDialogStage.show();
+            controller.setDialogStage(tmpDialogStage);
             // put into cache map
             SoftReference<BaseFXController> softReference = new SoftReference<>(controller);
             cacheNodeMap.put(fxmlPage, softReference);

--- a/src/main/java/com/zzg/mybatis/generator/controller/DbConnectionController.java
+++ b/src/main/java/com/zzg/mybatis/generator/controller/DbConnectionController.java
@@ -34,6 +34,7 @@ public class DbConnectionController extends BaseFXController {
     @FXML
     protected ChoiceBox<String> dbTypeChoice;
     protected MainUIController mainUIController;
+    protected TabPaneController tabPaneController;
     protected boolean isUpdate = false;
     protected Integer primayKey;
 
@@ -48,7 +49,7 @@ public class DbConnectionController extends BaseFXController {
         }
         try {
             ConfigHelper.saveDatabaseConfig(this.isUpdate, primayKey, config);
-            getDialogStage().close();
+            this.tabPaneController.getDialogStage().close();
             mainUIController.loadLeftDBTree();
         } catch (Exception e) {
             _LOG.error(e.getMessage(), e);
@@ -59,6 +60,10 @@ public class DbConnectionController extends BaseFXController {
     void setMainUIController(MainUIController controller) {
         this.mainUIController = controller;
         super.setDialogStage(mainUIController.getDialogStage());
+    }
+
+    public void setTabPaneController(TabPaneController tabPaneController) {
+        this.tabPaneController = tabPaneController;
     }
 
     public DatabaseConfig extractConfigForUI() {

--- a/src/main/java/com/zzg/mybatis/generator/controller/FXMLPage.java
+++ b/src/main/java/com/zzg/mybatis/generator/controller/FXMLPage.java
@@ -9,6 +9,7 @@ public enum FXMLPage {
 
     NEW_CONNECTION("fxml/newConnection.fxml"),
     SELECT_TABLE_COLUMN("fxml/selectTableColumn.fxml"),
+    TABLE_COLUMN_CONFIG("fxml/tableColumnConfigs.fxml"),
     GENERATOR_CONFIG("fxml/generatorConfigs.fxml"),
     ;
 

--- a/src/main/java/com/zzg/mybatis/generator/controller/OverSshController.java
+++ b/src/main/java/com/zzg/mybatis/generator/controller/OverSshController.java
@@ -202,7 +202,7 @@ public class OverSshController extends DbConnectionController {
         }
         try {
             ConfigHelper.saveDatabaseConfig(this.isUpdate, primayKey, databaseConfig);
-            getDialogStage().close();
+            this.tabPaneController.getDialogStage().close();
             mainUIController.loadLeftDBTree();
         } catch (Exception e) {
             logger.error(e.getMessage(), e);

--- a/src/main/java/com/zzg/mybatis/generator/controller/SelectTableColumnController.java
+++ b/src/main/java/com/zzg/mybatis/generator/controller/SelectTableColumnController.java
@@ -100,6 +100,14 @@ public class SelectTableColumnController extends BaseFXController {
         getDialogStage().close();
     }
 
+    @FXML
+    public void configAction() {
+        TableColumnConfigsController controller = (TableColumnConfigsController) loadFXMLPage("定制列配置", FXMLPage.TABLE_COLUMN_CONFIG,true);
+        controller.setColumnListView(this.columnListView);
+        controller.setTableName(this.tableName);
+        controller.showDialogStage();
+    }
+
     public void setColumnList(ObservableList<UITableColumnVO> columns) {
         columnListView.setItems(columns);
     }

--- a/src/main/java/com/zzg/mybatis/generator/controller/TabPaneController.java
+++ b/src/main/java/com/zzg/mybatis/generator/controller/TabPaneController.java
@@ -51,7 +51,9 @@ public class TabPaneController extends BaseFXController {
     public void setMainUIController(MainUIController mainUIController) {
         this.mainUIController = mainUIController;
         this.tabControlAController.setMainUIController(mainUIController);
+        this.tabControlAController.setTabPaneController(this);
         this.tabControlBController.setMainUIController(mainUIController);
+        this.tabControlBController.setTabPaneController(this);
     }
 
     public void setConfig(DatabaseConfig selectedConfig) {

--- a/src/main/java/com/zzg/mybatis/generator/controller/TableColumnConfigsController.java
+++ b/src/main/java/com/zzg/mybatis/generator/controller/TableColumnConfigsController.java
@@ -28,6 +28,7 @@ public class TableColumnConfigsController extends BaseFXController {
 
 	private static final Logger _LOG                  = LoggerFactory.getLogger(TableColumnConfigsController.class);
 	private static final String COL_NAME_PREFIX_REGEX = "(?<=%s)[^\"]+";   // pattern regex and split prefix: (?<=aggregate_|f_)[^"]+  f_ or d_ prefix
+	private static final String OR_REGEX              = "|";
 
 	@FXML
 	private Label     currentTableNameLabel;
@@ -73,6 +74,10 @@ public class TableColumnConfigsController extends BaseFXController {
 	private void genProertyNameByColumnNamePrefix() {
 		String columnNamePrefix = this.columnNamePrefixTextLabel.getText();
 		if (StringUtils.isNotBlank(columnNamePrefix)) {
+			if (StringUtils.endsWith(columnNamePrefix.trim(), OR_REGEX)) {
+				columnNamePrefix = StringUtils.removeEnd(columnNamePrefix.trim(), OR_REGEX);
+			}
+
 			String regex = String.format(COL_NAME_PREFIX_REGEX, columnNamePrefix);
 			_LOG.info("table:{}, column_name_prefix:{}, regex:{}", this.tableName, columnNamePrefix, regex);
 

--- a/src/main/java/com/zzg/mybatis/generator/controller/TableColumnConfigsController.java
+++ b/src/main/java/com/zzg/mybatis/generator/controller/TableColumnConfigsController.java
@@ -1,0 +1,106 @@
+package com.zzg.mybatis.generator.controller;
+
+import com.zzg.mybatis.generator.model.UITableColumnVO;
+import com.zzg.mybatis.generator.view.AlertUtil;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.control.TableView;
+import javafx.scene.control.TextField;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.mybatis.generator.internal.util.JavaBeansUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.ResourceBundle;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * 定制列配置UI Controller
+ *
+ * @author xueqi
+ * @date 2021-06-24
+ */
+public class TableColumnConfigsController extends BaseFXController {
+
+	private static final Logger _LOG                  = LoggerFactory.getLogger(TableColumnConfigsController.class);
+	private static final String COL_NAME_PREFIX_REGEX = "(?<=%s)[^\"]+";   // pattern regex and split prefix: (?<=aggregate_|f_)[^"]+  f_ or d_ prefix
+
+	@FXML
+	private Label     currentTableNameLabel;
+	@FXML
+	private TextField columnNamePrefixTextLabel;
+
+	private TableView<UITableColumnVO> columnListView;
+	private String                     tableName;
+
+	@Override
+	public void initialize(URL location, ResourceBundle resources) {
+		// do nothing
+	}
+
+	@FXML
+	public void cancel() {
+		this.closeDialogStage();
+	}
+
+	@FXML
+	public void confirm() {
+		try {
+			// 1. generator bean propert name
+			this.genProertyNameByColumnNamePrefix();
+
+			// close window
+			this.closeDialogStage();
+		} catch (Exception e) {
+			_LOG.error("confirm throw exception.", e);
+			AlertUtil.showErrorAlert(e.getMessage());
+		}
+	}
+
+	public void setColumnListView(TableView<UITableColumnVO> columnListView) {
+		this.columnListView = columnListView;
+	}
+
+	public void setTableName(String tableName) {
+		this.tableName = tableName;
+		currentTableNameLabel.setText(tableName);
+	}
+
+	private void genProertyNameByColumnNamePrefix() {
+		String columnNamePrefix = this.columnNamePrefixTextLabel.getText();
+		if (StringUtils.isNotBlank(columnNamePrefix)) {
+			String regex = String.format(COL_NAME_PREFIX_REGEX, columnNamePrefix);
+			_LOG.info("table:{}, column_name_prefix:{}, regex:{}", this.tableName, columnNamePrefix, regex);
+
+			Pattern pattern = Pattern.compile(regex, Pattern.CASE_INSENSITIVE);
+
+			ObservableList<UITableColumnVO> items = columnListView.getItems();
+			if (CollectionUtils.isNotEmpty(items)) {
+				items.stream().forEach(item -> {
+					String  columnName = item.getColumnName();
+					Matcher matcher    = pattern.matcher(columnName);
+					if (matcher.find()) {
+						// use first match result
+						String regexColumnName = matcher.group();
+						if (StringUtils.isNotBlank(regexColumnName)) {
+							String propertyName = JavaBeansUtil.getCamelCaseString(regexColumnName, false);
+							_LOG.debug("table:{} column_name:{} regex_column_name:{} property_name:{}", tableName, columnName, regexColumnName, propertyName);
+
+							if (StringUtils.isNotBlank(propertyName)) item.setPropertyName(propertyName);
+						} else {
+							_LOG.warn("table:{} column_name:{} regex_column_name is blank", tableName, columnName);
+						}
+					} else {
+						// if not match, set property name is null
+						item.setPropertyName(null);
+					}
+				});
+			}
+		}
+	}
+
+}

--- a/src/main/resources/fxml/selectTableColumn.fxml
+++ b/src/main/resources/fxml/selectTableColumn.fxml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<?import javafx.scene.text.*?>
-<?import javafx.scene.control.*?>
-<?import javafx.scene.layout.*?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.TableColumn?>
+<?import javafx.scene.control.TableView?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.text.Text?>
 
-<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="526.0" prefWidth="730.0" xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.zzg.mybatis.generator.controller.SelectTableColumnController">
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="526.0" prefWidth="730.0" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.zzg.mybatis.generator.controller.SelectTableColumnController">
    <children>
-      <TableView fx:id="columnListView" editable="true" prefHeight="200.0" prefWidth="200.0" AnchorPane.bottomAnchor="50.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="100.0">
+      <TableView fx:id="columnListView" editable="true" layoutY="123.0" prefHeight="353.0" prefWidth="730.0" AnchorPane.bottomAnchor="50.0" AnchorPane.leftAnchor="0.0" AnchorPane.rightAnchor="0.0" AnchorPane.topAnchor="100.0">
         <columns>
           <TableColumn fx:id="checkedColumn" prefWidth="75.0" text="Checked" />
           <TableColumn fx:id="columnNameColumn" prefWidth="132.0" text="Column Name" />
@@ -23,5 +25,6 @@
       <Button focusTraversable="false" layoutX="556.0" layoutY="486.0" mnemonicParsing="false" onAction="#cancel" text="取消" AnchorPane.bottomAnchor="13.0" AnchorPane.rightAnchor="113.0" />
       <Text layoutX="12.0" layoutY="62.0" lineSpacing="5.0" strokeType="OUTSIDE" strokeWidth="0.0" text="2. 如果要定制列的Java数据类型, 编辑Java Type和Property Name或者你自己的Type Handler, 注意要按Enter键保存，然后再点击确认方可生效。" wrappingWidth="706.0" />
       <Text layoutX="14.0" layoutY="35.0" strokeType="OUTSIDE" strokeWidth="0.0" text="1. 如果不想生成某列请取消勾选对应的列" />
+      <Button focusTraversable="false" layoutX="14.0" layoutY="489.0" mnemonicParsing="false" onAction="#configAction" text="配置" />
    </children>
 </AnchorPane>

--- a/src/main/resources/fxml/selectTableColumn.fxml
+++ b/src/main/resources/fxml/selectTableColumn.fxml
@@ -25,6 +25,6 @@
       <Button focusTraversable="false" layoutX="556.0" layoutY="486.0" mnemonicParsing="false" onAction="#cancel" text="取消" AnchorPane.bottomAnchor="13.0" AnchorPane.rightAnchor="113.0" />
       <Text layoutX="12.0" layoutY="62.0" lineSpacing="5.0" strokeType="OUTSIDE" strokeWidth="0.0" text="2. 如果要定制列的Java数据类型, 编辑Java Type和Property Name或者你自己的Type Handler, 注意要按Enter键保存，然后再点击确认方可生效。" wrappingWidth="706.0" />
       <Text layoutX="14.0" layoutY="35.0" strokeType="OUTSIDE" strokeWidth="0.0" text="1. 如果不想生成某列请取消勾选对应的列" />
-      <Button focusTraversable="false" layoutX="14.0" layoutY="489.0" mnemonicParsing="false" onAction="#configAction" text="配置" />
+      <Button focusTraversable="false" layoutX="14.0" layoutY="489.0" mnemonicParsing="false" onAction="#configAction" text="属性配置" />
    </children>
 </AnchorPane>

--- a/src/main/resources/fxml/tableColumnConfigs.fxml
+++ b/src/main/resources/fxml/tableColumnConfigs.fxml
@@ -29,7 +29,7 @@
                   <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
               </rowConstraints>
                <children>
-                  <Label alignment="TOP_RIGHT" contentDisplay="RIGHT" prefHeight="17.0" prefWidth="202.0" text="列名称前缀(多种前缀使用|分割):" textAlignment="RIGHT" GridPane.rowIndex="2">
+                  <Label alignment="TOP_RIGHT" contentDisplay="RIGHT" prefHeight="17.0" prefWidth="202.0" text="去除前缀(多种前缀使用|分割):" textAlignment="RIGHT" GridPane.rowIndex="2">
                      <GridPane.margin>
                         <Insets top="5.0" />
                      </GridPane.margin>

--- a/src/main/resources/fxml/tableColumnConfigs.fxml
+++ b/src/main/resources/fxml/tableColumnConfigs.fxml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import java.lang.String?>
+<?import javafx.geometry.Insets?>
+<?import javafx.scene.control.Button?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.control.TextField?>
+<?import javafx.scene.layout.AnchorPane?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.RowConstraints?>
+<?import javafx.scene.layout.VBox?>
+
+
+<AnchorPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="-Infinity" minWidth="-Infinity" prefHeight="205.0" prefWidth="538.0" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1" fx:controller="com.zzg.mybatis.generator.controller.TableColumnConfigsController">
+   <children>
+      <VBox prefHeight="64.0" prefWidth="538.0" AnchorPane.leftAnchor="5.0" AnchorPane.rightAnchor="5.0" AnchorPane.topAnchor="5.0">
+         <children>
+            <GridPane alignment="TOP_RIGHT" vgap="5.0">
+              <columnConstraints>
+                  <ColumnConstraints hgrow="SOMETIMES" maxWidth="332.0" minWidth="10.0" prefWidth="302.0" />
+                  <ColumnConstraints hgrow="SOMETIMES" maxWidth="332.0" minWidth="10.0" prefWidth="235.0" />
+                  <ColumnConstraints hgrow="SOMETIMES" maxWidth="332.0" minWidth="10.0" prefWidth="235.0" />
+              </columnConstraints>
+              <rowConstraints>
+                <RowConstraints />
+                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+                  <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+              </rowConstraints>
+               <children>
+                  <Label alignment="TOP_RIGHT" contentDisplay="RIGHT" prefHeight="17.0" prefWidth="202.0" text="列名称前缀(多种前缀使用|分割):" textAlignment="RIGHT" GridPane.rowIndex="2">
+                     <GridPane.margin>
+                        <Insets top="5.0" />
+                     </GridPane.margin>
+                  </Label>
+                  <TextField fx:id="columnNamePrefixTextLabel" prefHeight="23.0" prefWidth="213.0" GridPane.columnIndex="1" GridPane.rowIndex="2">
+                     <GridPane.margin>
+                        <Insets top="5.0" />
+                     </GridPane.margin>
+                  </TextField>
+                  <Label alignment="TOP_RIGHT" contentDisplay="RIGHT" prefHeight="17.0" prefWidth="202.0" text="当前表名称:" textAlignment="RIGHT" GridPane.rowIndex="1">
+                     <GridPane.margin>
+                        <Insets bottom="10.0" />
+                     </GridPane.margin>
+                  </Label>
+                  <Label fx:id="currentTableNameLabel" alignment="TOP_LEFT" contentDisplay="RIGHT" prefHeight="17.0" prefWidth="202.0" textAlignment="CENTER" GridPane.columnIndex="1" GridPane.rowIndex="1">
+                     <GridPane.margin>
+                        <Insets bottom="10.0" />
+                     </GridPane.margin>
+                  </Label>
+               </children>
+               <VBox.margin>
+                  <Insets top="5.0" />
+               </VBox.margin>
+            </GridPane>
+         </children>
+      </VBox>
+      <Button layoutX="476.0" layoutY="169.0" mnemonicParsing="false" onAction="#confirm" text="确认">
+         <styleClass>
+            <String fx:value="btn" />
+            <String fx:value="btn-default" />
+         </styleClass>
+      </Button>
+      <Button layoutX="412.0" layoutY="169.0" mnemonicParsing="false" onAction="#cancel" text="取消">
+         <styleClass>
+            <String fx:value="btn" />
+            <String fx:value="btn-default" />
+         </styleClass>
+      </Button>
+   </children>
+</AnchorPane>


### PR DESCRIPTION
1. 定制列界面新增「配置」按钮，新增「定制列配置」界面
2. 输入列名前缀，支持多种前缀，例如：「f_|d_」。表示该表中，所有前缀为 f_ 或 d_ 的字段，自动生成不含前缀的propertyName
```
column_name: f_id  --> propertyName: id
column_name: d_user_state --> propertyName: userState
```
3. 生成后的propertyName仍可以自定义修改
4. 使用MyBatis Gnerator中`getCamelCaseString`方法，针对分割后列名为`_user_state`的格式，生成驼峰属性名：userState
5. 已执行测试用例
  - 空值： 不会自动生成propertyName
  - f_ ： 表中f_开头的列自动生成propertName
  - f_|d_ ：表中 f_ 或 d_ 开头列自动生成propertName
  - f_| ：表中f_开头的列自动生成propertName