### PR TITLE
fix m1 sqlite jar error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ logs
 .classpath
 /src/main/resources/sqlite3.db
 /config/
+.DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -40,10 +40,11 @@
             <artifactId>commons-io</artifactId>
             <version>[2.7,)</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.xerial/sqlite-jdbc -->
         <dependency>
             <groupId>org.xerial</groupId>
             <artifactId>sqlite-jdbc</artifactId>
-            <version>3.8.11.2</version>
+            <version>3.36.0.3</version>
         </dependency>
         <dependency>
             <groupId>commons-beanutils</groupId>


### PR DESCRIPTION
在M1 MacBook Pro的直接运行会报错，No native library is found for os.name=Mac and os.arch=aarch64，升级sqlite包版本后解决。