### PR TITLE
fix(sec): upgrade commons-beanutils:commons-beanutils to 1.9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>1.9.2</version>
+            <version>1.9.4</version>
         </dependency>
         <dependency>
             <groupId>com.alibaba</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in commons-beanutils:commons-beanutils 1.9.2
- [CVE-2019-10086](https://www.oscs1024.com/hd/CVE-2019-10086)


### What did I do？
Upgrade commons-beanutils:commons-beanutils from 1.9.2 to 1.9.4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS