### PR TITLE
fix(sec): upgrade com.alibaba:fastjson to 1.2.83

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
         <dependency>
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
-            <version>1.2.76</version>
+            <version>1.2.83</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in com.alibaba:fastjson 1.2.76
- [CVE-2022-25845](https://www.oscs1024.com/hd/CVE-2022-25845)


### What did I do？
Upgrade com.alibaba:fastjson from 1.2.76 to 1.2.83 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS