### PR TITLE
fix(sec): upgrade ch.qos.logback:logback-core to 1.2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.2.0</version>
+            <version>1.2.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in ch.qos.logback:logback-core 1.2.0
- [MPS-2022-12411](https://www.oscs1024.com/hd/MPS-2022-12411)


### What did I do？
Upgrade ch.qos.logback:logback-core from 1.2.0 to 1.2.7 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS